### PR TITLE
Add Blog

### DIFF
--- a/src/content/blog/first-post.md
+++ b/src/content/blog/first-post.md
@@ -1,0 +1,7 @@
+---
+title: "My First Blog Post"
+pubDate: "2023-10-26"
+description: "This is the very first post on my new blog!"
+---
+
+Hello world! This is my first blog post. I'm excited to start sharing my thoughts.

--- a/src/content/blog/fourth-post.md
+++ b/src/content/blog/fourth-post.md
@@ -1,0 +1,7 @@
+---
+title: "The Future of Web Development"
+pubDate: "2023-10-29"
+description: "Some thoughts on where the web is heading."
+---
+
+The web is constantly evolving. Here are some of my predictions.

--- a/src/content/blog/second-post.md
+++ b/src/content/blog/second-post.md
@@ -1,0 +1,7 @@
+---
+title: "A Look at Astro Content Collections"
+pubDate: "2023-10-27"
+description: "Exploring how Astro helps manage content."
+---
+
+Astro's content collections are a powerful feature for building static sites.

--- a/src/content/blog/third-post.md
+++ b/src/content/blog/third-post.md
@@ -1,0 +1,6 @@
+---
+title: "Tailwind CSS for Styling"
+pubDate: "2023-10-28"
+---
+
+Tailwind CSS makes styling a breeze. Let's see how it integrates with Astro.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -13,4 +13,14 @@ const projects = defineCollection({
 	}),
 });
 
-export const collections = { projects };
+const blog = defineCollection({
+	type: 'content',
+	schema: z.object({
+		title: z.string(),
+		description: z.string().optional(),
+		pubDate: z.coerce.date(),
+		updatedDate: z.coerce.date().optional(),
+	}),
+});
+
+export const collections = { projects, blog };

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,0 +1,57 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import FormattedDate from '../components/FormattedDate.astro';
+import { SITE_TITLE } from '../consts'; // Assuming SITE_TITLE is used for page titles
+
+const { frontmatter } = Astro.props;
+const pageTitle = `${frontmatter.title} | ${SITE_TITLE}`;
+---
+<!doctype html>
+<html lang="en">
+<head>
+    <BaseHead title={pageTitle} description={frontmatter.description} />
+    <style>
+        main {
+            max-width: 800px; /* Or your preferred max-width for blog posts */
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }
+        .post-title {
+            font-size: 2.5rem; /* Example size */
+            font-weight: bold;
+            margin-bottom: 0.5rem;
+            color: var(--color-text); /* Adjust to your site's text color variable if available */
+        }
+        .post-date {
+            font-size: 0.9rem;
+            color: var(--color-text-secondary); /* Adjust to your site's secondary text color */
+            margin-bottom: 2rem;
+        }
+        .prose {
+            /* Add any specific prose styling overrides here if needed */
+        }
+    </style>
+</head>
+<body>
+    <Header />
+    <main>
+        <article class="prose prose-lg mx-auto">
+            <h1 class="post-title">{frontmatter.title}</h1>
+            {frontmatter.pubDate && (
+                <p class="post-date">
+                    Published on: <FormattedDate date={frontmatter.pubDate} />
+                </p>
+            )}
+            {frontmatter.updatedDate && (
+                <p class="post-date" style="margin-top: -1.5rem; font-size: 0.8rem;">
+                    Last updated: <FormattedDate date={frontmatter.updatedDate} />
+                </p>
+            )}
+            <slot /> {/* This is where the Markdown content will be injected */}
+        </article>
+    </main>
+    <Footer />
+</body>
+</html>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,20 @@
+---
+import { type CollectionEntry, getCollection } from 'astro:content';
+import BlogPostLayout from '../../layouts/BlogPost.astro'; // Corrected path
+
+export async function getStaticPaths() {
+    const posts = await getCollection('blog'); // Use the 'blog' collection
+    return posts.map((post) => ({
+        params: { slug: post.slug },
+        props: post,
+    }));
+}
+
+type Props = CollectionEntry<'blog'>; // Use 'blog' collection type
+
+const post = Astro.props;
+const { Content } = await post.render();
+---
+<BlogPostLayout frontmatter={post.data}> {/* Pass frontmatter explicitly */}
+    <Content />
+</BlogPostLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,86 @@
+---
+import BaseHead from '../../components/BaseHead.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import FormattedDate from '../../components/FormattedDate.astro';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts'; // Assuming these are general site constants
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog')).sort(
+    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+);
+
+const pageTitle = `Blog | ${SITE_TITLE}`;
+---
+<!doctype html>
+<html lang="en">
+<head>
+    <BaseHead title={pageTitle} description={`All blog posts from ${SITE_TITLE}.`} />
+    <style>
+        main {
+            max-width: 960px; /* Consistent with commented out _projects/index.astro */
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }
+        .blog-list {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+        }
+        .blog-list li {
+            margin-bottom: 2rem;
+            padding-bottom: 1rem;
+            border-bottom: 1px solid #eee; /* Light separator */
+        }
+        .blog-list li:last-child {
+            border-bottom: none;
+        }
+        .post-link {
+            text-decoration: none;
+            color: var(--color-text); /* Adjust to your site's text color */
+        }
+        .post-link:hover .post-title {
+            color: var(--color-primary); /* Adjust to your site's primary/accent color */
+        }
+        .post-title {
+            font-size: 1.75rem; /* Example size */
+            font-weight: bold;
+            margin-bottom: 0.25rem;
+        }
+        .post-date {
+            font-size: 0.9rem;
+            color: var(--color-text-secondary); /* Adjust to your site's secondary text color */
+            margin-bottom: 0.5rem;
+        }
+        .post-description {
+            font-size: 1rem;
+            color: var(--color-text-muted); /* Adjust as needed */
+        }
+    </style>
+</head>
+<body>
+    <Header />
+    <main>
+        <h1>Blog</h1>
+        <p>All my thoughts, sorted chronologically.</p>
+        <section>
+            <ul class="blog-list">
+                {posts.map((post) => (
+                    <li>
+                        <a href={`/blog/${post.slug}/`} class="post-link">
+                            <h2 class="post-title">{post.data.title}</h2>
+                            <p class="post-date">
+                                <FormattedDate date={post.data.pubDate} />
+                            </p>
+                            {post.data.description && (
+                                <p class="post-description">{post.data.description}</p>
+                            )}
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    </main>
+    <Footer />
+</body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,12 @@ import { Image } from 'astro:assets';
 import BaseHead from '../components/BaseHead.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 import idanImage from './_idan.jpg';
+import { getCollection } from 'astro:content';
+import FormattedDate from '../components/FormattedDate.astro';
+
+const allBlogPosts = (await getCollection('blog'))
+    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const recentBlogPosts = allBlogPosts.slice(0, 3);
 ---
 
 <!doctype html>
@@ -40,6 +46,32 @@ import idanImage from './_idan.jpg';
                                                 the first widely-adopted application of generative AI. Mostly, this job is about improving the
                                                 lives of developers while avoiding buzzwords about innovation.
 						</p>
+
+						<div class="pt-6">
+							<h3 class="text-xl font-semibold mb-4">Latest Thoughts</h3>
+							<ul class="list-none p-0 m-0">
+								{recentBlogPosts.map(post => (
+									<li class="mb-3">
+										<a href={`/blog/${post.slug}/`} class="text-primary-50 hover:text-primary-400">
+											<h4 class="text-lg font-medium">{post.data.title}</h4>
+											<p class="text-sm text-primary-300">
+												<FormattedDate date={post.data.pubDate} />
+											</p>
+										</a>
+										{post.data.description && (
+											<p class="text-sm text-primary-200 mt-1">{post.data.description}</p>
+										)}
+									</li>
+								))}
+							</ul>
+							{allBlogPosts.length > 3 && (
+								 <p class="mt-4">
+									 <a href="/blog" class="text-primary-50 hover:text-primary-400 underline">
+										 Read all posts &rarr;
+									 </a>
+								 </p>
+							)}
+						</div>
 
 						<div class="pb-5 flex flex-row items-baseline">
 							<p class="pr-2 flex-grow-0">


### PR DESCRIPTION
feat: Add blog structure and initial posts

This commit introduces a complete blog structure to the website.

Key changes include:
- Added a new 'blog' content collection in `src/content/config.ts` with fields for title, publication date, and optional description.
- Created several sample blog posts in `src/content/blog/` to populate the blog.
- Implemented `src/layouts/BlogPost.astro` as the layout for individual blog posts, including styling for readability using Tailwind's prose classes.
- Added `src/pages/blog/[...slug].astro` to dynamically generate pages for each blog post.
- Created `src/pages/blog/index.astro` to display a reverse-chronological list of all blog posts, with links to individual entries.
- Updated the homepage (`src/pages/index.astro`) to display the three most recent blog posts below the main introduction, along with a link to the full blog listing page.
- Ensured basic styling for all new elements, primarily using Tailwind CSS and consistency with the existing site design.