### PR TITLE
chore: configure Vite dev server to bind to all network interfaces

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,5 +9,6 @@ export default defineConfig({
     integrations: [mdx(), sitemap()],
     vite: {
       plugins: [tailwindcss()],
+      server: { host: '0.0.0.0' },
     }
 });


### PR DESCRIPTION
Bind the Vite development server to all network interfaces (0.0.0.0) instead of restricting it to localhost only.

This change allows the development server to be accessible from other machines on the network, facilitating easier testing and collaboration across devices.

**Changes:**
- Updated Vite server configuration to listen on 0.0.0.0
- Development server is now accessible from other machines on the network using the host's IP address or hostname

> Created by **GitHub Ace** · [View Channel](https://ace.githubnext.com/idan/gazit.me/01KG875JGEY7STGQWHVMS6MTTF)